### PR TITLE
Add metrics feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ try (RawResponse response = client.select("http://localhost:8123", "SELECT * FRO
 ## How to add clickhouse-client into your project
 ### Gradle
 ```
-compile "com.ecwid.clickhouse:clickhouse-client:0.5.0"
+compile "com.ecwid.clickhouse:clickhouse-client:0.6.0"
 ```
 ### Maven
 ```
 <dependency>
   <groupId>com.ecwid.clickhouse</groupId>
   <artifactId>clickhouse-client</artifactId>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
 	implementation("org.apache.httpcomponents:httpcore:4.4.15")
 	implementation("org.apache.httpcomponents:httpclient:4.5.13")
 
+	compileOnly("io.prometheus:simpleclient:0.16.0")
+
 	testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
 	testImplementation("org.mockito:mockito-core:2.15.0")

--- a/src/main/kotlin/com/ecwid/clickhouse/mapped/ClickHouseMappedClient.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/mapped/ClickHouseMappedClient.kt
@@ -11,8 +11,9 @@ import com.ecwid.clickhouse.typed.TypedValues
 
 class ClickHouseMappedClient(
 	httpTransport: HttpTransport,
-	metrics: Metrics = DefaultMetrics.NONE
+	metrics: Metrics
 ) {
+	constructor(httpTransport: HttpTransport): this(httpTransport, DefaultMetrics.NONE)
 
 	private val typedClient = ClickHouseTypedClient(httpTransport, metrics)
 

--- a/src/main/kotlin/com/ecwid/clickhouse/mapped/ClickHouseMappedClient.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/mapped/ClickHouseMappedClient.kt
@@ -1,15 +1,20 @@
 package com.ecwid.clickhouse.mapped
 
 import com.ecwid.clickhouse.ClickHouseResponse
+import com.ecwid.clickhouse.metrics.DefaultMetrics
+import com.ecwid.clickhouse.metrics.Metrics
 import com.ecwid.clickhouse.raw.ClickHouseRawClient
 import com.ecwid.clickhouse.transport.HttpTransport
 import com.ecwid.clickhouse.typed.ClickHouseTypedClient
 import com.ecwid.clickhouse.typed.TypedRow
 import com.ecwid.clickhouse.typed.TypedValues
 
-class ClickHouseMappedClient(httpTransport: HttpTransport) {
+class ClickHouseMappedClient(
+	httpTransport: HttpTransport,
+	metrics: Metrics = DefaultMetrics.NONE
+) {
 
-	private val typedClient = ClickHouseTypedClient(httpTransport)
+	private val typedClient = ClickHouseTypedClient(httpTransport, metrics)
 
 	fun <T> select(host: String, sqlQuery: String, mapper: (TypedRow) -> T): ClickHouseResponse<T> {
 		val typedResponse = typedClient.select(host, sqlQuery)

--- a/src/main/kotlin/com/ecwid/clickhouse/metrics/DefaultMetrics.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/metrics/DefaultMetrics.kt
@@ -1,0 +1,25 @@
+package com.ecwid.clickhouse.metrics
+
+object DefaultMetrics {
+	/**
+	 * No metrics will be collected
+	 */
+	val NONE = object : Metrics {
+		private val emptyTimer = AutoCloseable {
+			// noting to do
+		}
+
+		override fun startRequestTimer(host: String): AutoCloseable {
+			return emptyTimer
+		}
+
+		override fun measureRequest(host: String, statusCode: Int) {
+			// nothing to do
+		}
+	}
+
+	/**
+	 * Use prometheus metrics lib
+	 */
+	val PROMETHEUS: Metrics by lazy(::PrometheusMetrics)
+}

--- a/src/main/kotlin/com/ecwid/clickhouse/metrics/Metrics.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/metrics/Metrics.kt
@@ -1,0 +1,13 @@
+package com.ecwid.clickhouse.metrics
+
+interface Metrics {
+	/**
+	 * Returns autocloseable instance, which must do measure on close invoke
+	 */
+	fun startRequestTimer(host: String): AutoCloseable
+
+	/**
+	 * Measure one request
+	 */
+	fun measureRequest(host: String, statusCode: Int)
+}

--- a/src/main/kotlin/com/ecwid/clickhouse/metrics/PrometheusMetrics.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/metrics/PrometheusMetrics.kt
@@ -1,0 +1,36 @@
+package com.ecwid.clickhouse.metrics
+
+import io.prometheus.client.Counter
+import io.prometheus.client.Summary
+
+/**
+ * Metrics will be collected to prometheus lib
+ */
+class PrometheusMetrics : Metrics {
+	override fun startRequestTimer(host: String): AutoCloseable {
+		return requestsLatencySummary.labels(host).startTimer()
+	}
+
+	override fun measureRequest(host: String, statusCode: Int) {
+		requestsCounter.labels(host, statusCode.toString()).inc()
+	}
+
+	companion object {
+		private val requestsLatencySummary = Summary.Builder()
+			.subsystem("clickhouse_client")
+			.name("requests_latency_seconds")
+			.help("Latency of requests in seconds")
+			.labelNames("host")
+			.quantile(0.5, 0.01)
+			.quantile(0.95, 0.01)
+			.quantile(0.99, 0.01)
+			.register()
+
+		private val requestsCounter = Counter.Builder()
+			.subsystem("clickhouse_client")
+			.name("requests_total")
+			.help("Total number of requests")
+			.labelNames("host", "http_code")
+			.register()
+	}
+}

--- a/src/main/kotlin/com/ecwid/clickhouse/raw/RawResponse.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/raw/RawResponse.kt
@@ -6,7 +6,10 @@ import com.ecwid.clickhouse.Statistics
 import com.ecwid.clickhouse.transport.HttpResponse
 import com.google.gson.stream.JsonReader
 
-internal class RawResponse(private val httpResponse: HttpResponse) : ClickHouseResponse<RawRow> {
+internal class RawResponse(
+	private val httpResponse: HttpResponse,
+	private val callTimer: AutoCloseable
+) : ClickHouseResponse<RawRow> {
 
 	private val jsonReader = JsonReader(httpResponse.content.asReader())
 	private var iterationState = IterationState.BEFORE_ITERATION
@@ -46,6 +49,7 @@ internal class RawResponse(private val httpResponse: HttpResponse) : ClickHouseR
 
 	override fun close() {
 		httpResponse.close()
+		callTimer.close()
 	}
 
 	internal fun completeIteration() {

--- a/src/main/kotlin/com/ecwid/clickhouse/typed/ClickHouseTypedClient.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/typed/ClickHouseTypedClient.kt
@@ -1,14 +1,18 @@
 package com.ecwid.clickhouse.typed
 
 import com.ecwid.clickhouse.ClickHouseResponse
+import com.ecwid.clickhouse.metrics.Metrics
 import com.ecwid.clickhouse.raw.ClickHouseRawClient
 import com.ecwid.clickhouse.transport.HttpTransport
 import java.util.*
 
-class ClickHouseTypedClient(httpTransport: HttpTransport) {
+class ClickHouseTypedClient(
+	httpTransport: HttpTransport,
+	metrics: Metrics
+) {
 
 	private val defaultTimeZone = TimeZone.getTimeZone("UTC")
-	private val rawClient = ClickHouseRawClient(httpTransport)
+	private val rawClient = ClickHouseRawClient(httpTransport, metrics)
 
 	fun select(host: String, sqlQuery: String, timeZone: TimeZone): ClickHouseResponse<TypedRow> {
 		val rawResponse = rawClient.select(host, sqlQuery)


### PR DESCRIPTION
ClickHouseRawClient now measures requests through the Metrics interface. Added several implementations of metrics:
* NONE - without collecting metrics
* PROMETHEUS - collects metrics to the prometheus collector

Default metrics collector is NONE