### PR TITLE
Update GitHub workflow and build.gradle for release

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -1,8 +1,9 @@
 name: On push to master
 
 on:
-  release:
-    types: [published]
+  push:
+      branches:
+          - master
 
 jobs:
   build:
@@ -12,12 +13,12 @@ jobs:
     steps:
 
       - name: Checkout full repository history
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -33,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build, upload release version to Maven Central and create git release tag with Gradle
-        run: ./gradlew final closeAndReleaseRepository printFinalReleaseNode
+        run: ./gradlew final closeAndReleaseStagingRepository printFinalReleaseNote
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Add prometheus metric dependency to your project
 
 gradle
 ```
-compileOnly "io.prometheus:simpleclient:0.16.0"
+compile "io.prometheus:simpleclient:0.16.0"
 ```
 
 Inject metrics collector on instantiate client


### PR DESCRIPTION
Modified GitHub Action workflow and build.gradle to use a newer version of GitHub Actions and plugins respectively. Changes in GitHub workflow include switching from 'actions/checkout@v2' to 'actions/checkout@v3' and 'actions/setup-java@v2' to 'actions/setup-java@v3'. Changed triggering event from 'release' to 'push to master'. In build.gradle, updated plugins, changed release configurations and added sonatype publish configuration for releasing to Maven Central. The changes ensure the workflow and build script use current versions with up-to-date functionality. To make publishing artefacts and pushing new git tag concurrent, also, to enable code releasing to Maven Central from 'push to master'.