### PR TITLE
Fix kotlin compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Add prometheus metric dependency to your project
 
 gradle
 ```
-compileOnly "io.prometheus:simpleclient:0.16.0"
+compile "io.prometheus:simpleclient:0.16.0"
 ```
 
 Inject metrics collector on instantiate client

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
 // Kotlin settings
 tasks.withType<KotlinCompile> {
 	kotlinOptions.jvmTarget = "11"
-	kotlinOptions.apiVersion = "1.7"
-	kotlinOptions.languageVersion = "1.7"
+	kotlinOptions.apiVersion = "1.6"
+	kotlinOptions.languageVersion = "1.6"
 }
 
 // Unit tests settings


### PR DESCRIPTION
New version fails compilation with:
```
Class 'com.ecwid.clickhouse.ClickHouseResponse' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
```

Will downgrade api version