### PR TITLE
Update prometheus to 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Add prometheus metric dependency to your project
 
 gradle
 ```
-compile "io.prometheus:simpleclient:0.16.0"
+compile "io.prometheus:prometheus-metrics-core:1.2.0"
 ```
 
 Inject metrics collector on instantiate client

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
 	java
-	kotlin("jvm") version "1.6.10"
+	kotlin("jvm") version "1.9.23"
 	signing
 	`maven-publish`
 	id("com.netflix.nebula.release") version "17.2.2"
@@ -19,17 +19,15 @@ dependencies {
 	implementation(kotlin("stdlib-jdk8"))
 	implementation(kotlin("reflect"))
 
-	implementation("com.google.code.gson:gson:2.9.0")
+	implementation("com.google.code.gson:gson:2.10.1")
 
-	implementation("org.apache.httpcomponents:httpcore:4.4.15")
-	implementation("org.apache.httpcomponents:httpclient:4.5.13")
+	implementation("org.apache.httpcomponents:httpcore:4.4.16")
+	implementation("org.apache.httpcomponents:httpclient:4.5.14")
 
 	compileOnly("io.prometheus:prometheus-metrics-core:1.2.0")
 
-	testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
-	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
-	testImplementation("org.mockito:mockito-core:2.15.0")
-	testImplementation("org.hamcrest:hamcrest-library:1.3")
+	testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
 	testImplementation("org.slf4j:slf4j-simple:1.7.36")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 	implementation("org.apache.httpcomponents:httpcore:4.4.15")
 	implementation("org.apache.httpcomponents:httpclient:4.5.13")
 
-	compileOnly("io.prometheus:simpleclient:0.16.0")
+	compileOnly("io.prometheus:prometheus-metrics-core:1.2.0")
 
 	testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")

--- a/src/main/kotlin/com/ecwid/clickhouse/metrics/PrometheusMetrics.kt
+++ b/src/main/kotlin/com/ecwid/clickhouse/metrics/PrometheusMetrics.kt
@@ -1,24 +1,24 @@
 package com.ecwid.clickhouse.metrics
 
-import io.prometheus.client.Counter
-import io.prometheus.client.Summary
+import io.prometheus.metrics.core.metrics.Counter
+import io.prometheus.metrics.core.metrics.Summary
+
 
 /**
  * Metrics will be collected to prometheus lib
  */
 class PrometheusMetrics : Metrics {
 	override fun startRequestTimer(host: String): AutoCloseable {
-		return requestsLatencySummary.labels(host).startTimer()
+		return requestsLatencySummary.labelValues(host).startTimer()
 	}
 
 	override fun measureRequest(host: String, statusCode: Int) {
-		requestsCounter.labels(host, statusCode.toString()).inc()
+		requestsCounter.labelValues(host, statusCode.toString()).inc()
 	}
 
 	companion object {
-		private val requestsLatencySummary = Summary.Builder()
-			.subsystem("clickhouse_client")
-			.name("requests_latency_seconds")
+		private val requestsLatencySummary = Summary.builder()
+			.name("clickhouse_client_requests_latency_seconds")
 			.help("Latency of requests in seconds")
 			.labelNames("host")
 			.quantile(0.5, 0.01)
@@ -26,9 +26,8 @@ class PrometheusMetrics : Metrics {
 			.quantile(0.99, 0.01)
 			.register()
 
-		private val requestsCounter = Counter.Builder()
-			.subsystem("clickhouse_client")
-			.name("requests_total")
+		private val requestsCounter = Counter.builder()
+			.name("clickhouse_client_requests_total")
 			.help("Total number of requests")
 			.labelNames("host", "http_code")
 			.register()


### PR DESCRIPTION
This pull request includes changes to the `PrometheusMetrics.kt` file in the `src/main/kotlin/com/ecwid/clickhouse/metrics` directory. The changes are focused on modifying the import statements and the methods used for metrics collection. 

Key changes include:

* [`src/main/kotlin/com/ecwid/clickhouse/metrics/PrometheusMetrics.kt`](diffhunk://#diff-32303d1cfd09fee2c391befaef884cf9fe427331c397289491bbc67315361bd9L3-R30): The import statements for `Counter` and `Summary` have been updated to use `io.prometheus.metrics.core.metrics.Counter` and `io.prometheus.metrics.core.metrics.Summary` respectively. The methods `startRequestTimer` and `measureRequest` have been updated to use `labelValues` instead of `labels`. The `requestsLatencySummary` and `requestsCounter` objects have been updated to use the `builder` method and their names have been updated to include the subsystem name.