### PR TITLE
Add dependabot update workflow and migrate to libs.versions.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,13 @@ tasks.withType<KotlinCompile> {
 	kotlinOptions.languageVersion = "1.6"
 }
 
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+	withJavadocJar()
+	withSourcesJar()
+}
+
 // Unit tests settings
 tasks.withType<Test> {
 	enableAssertions = true
@@ -49,12 +56,6 @@ tasks.withType<Test> {
 		showStandardStreams = false
 	}
 }
-
-java {
-	withSourcesJar()
-	withJavadocJar()
-}
-
 
 val settingsProvider = SettingsProvider()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,11 +4,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
 	java
-	kotlin("jvm") version "1.9.23"
+	alias(libs.plugins.kotlin.jvm)
 	signing
 	`maven-publish`
-	id("com.netflix.nebula.release") version "17.2.2"
-	id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+	alias(libs.plugins.nebula.release)
+	alias(libs.plugins.nexus.publish.plugin)
 }
 
 repositories {
@@ -19,16 +19,16 @@ dependencies {
 	implementation(kotlin("stdlib-jdk8"))
 	implementation(kotlin("reflect"))
 
-	implementation("com.google.code.gson:gson:2.10.1")
+	implementation(libs.gson)
 
-	implementation("org.apache.httpcomponents:httpcore:4.4.16")
-	implementation("org.apache.httpcomponents:httpclient:4.5.14")
+	implementation(libs.httpcomponents.httpcore)
+	implementation(libs.httpcomponents.httpclient)
 
-	compileOnly("io.prometheus:prometheus-metrics-core:1.2.0")
+	compileOnly(libs.prometheus.metrics.core)
 
-	testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
-	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
-	testImplementation("org.slf4j:slf4j-simple:1.7.36")
+	testRuntimeOnly(libs.junit.jupiter.engine)
+	testImplementation(libs.junit.jupiter.api)
+	testImplementation(libs.slf4j)
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,29 @@
+[versions]
+
+gson = "2.10.1"
+httpcomponents-httpclient = "4.5.14"
+httpcomponents-httpcore = "4.4.16"
+junit = "5.10.2"
+kotlin = "1.9.23"
+nebula = "17.2.2"
+prometheus = "1.2.0"
+nexus-publish-plugin = "1.3.0"
+slf4j = "1.7.36"
+
+[plugins]
+
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+nebula-release = { id = "com.netflix.nebula.release", version.ref = "nebula" }
+nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin" }
+
+[libraries]
+
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+httpcomponents-httpclient = { group = "org.apache.httpcomponents", name = "httpclient", version.ref = "httpcomponents-httpclient" }
+httpcomponents-httpcore = { group = "org.apache.httpcomponents", name = "httpcore", version.ref = "httpcomponents-httpcore" }
+prometheus-metrics-core = { group = "io.prometheus", name = "prometheus-metrics-core", version.ref = "prometheus" }
+
+# Testing
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request includes updates to the dependency management and build configuration for the project. The changes primarily focus on setting up Dependabot for automated dependency updates and updating Gradle and library versions.

Dependency management updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R16): Added configuration for Dependabot to manage updates for Gradle and GitHub Actions dependencies on a weekly schedule.

Library and plugin version updates:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR1-R29): Added version definitions for various libraries and plugins, including Gson, HTTP components, JUnit, Kotlin, Nebula, Prometheus, Nexus Publish Plugin, and SLF4J.

Build configuration update:

* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated the Gradle distribution URL to use version 8.13.