### PR TITLE
Update push-to-master.yml

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -32,7 +32,7 @@ jobs:
                     cache: 'gradle'
 
             -   name: Build
-                run: ./gradlew final closeAndReleaseStagingRepository printFinalReleaseNote
+                run: ./gradlew final closeAndReleaseStagingRepositories printFinalReleaseNote
                 env:
                     GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
                     GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}


### PR DESCRIPTION
This pull request updates the Gradle build command in the GitHub Actions workflow to fix a typo in the task name, ensuring the correct task is executed during the build process.

* [`.github/workflows/push-to-master.yml`](diffhunk://#diff-4481125581f6a6e45442b3c68646ec81508c0cd9fbce6cec9a9192a1a278a3c4L35-R35): Changed the Gradle task from `closeAndReleaseStagingRepository` to `closeAndReleaseStagingRepositories` to correct a typo in the task name.